### PR TITLE
Add server-port option to FedAvgServer and the two examples

### DIFF
--- a/docs/examples/mnist.md
+++ b/docs/examples/mnist.md
@@ -42,7 +42,7 @@ now start the server:
 ```
 
 By default the server will use http for transport.
-Alternatively the server can be use https:
+Alternatively the server can use https:
 
 ```sh
 (venv_dc_federated)> python mnist_fed_avg_server.py \

--- a/src/dc_federated/algorithms/fed_avg/fed_avg_server.py
+++ b/src/dc_federated/algorithms/fed_avg/fed_avg_server.py
@@ -39,9 +39,12 @@ class FedAvgServer(object):
         The list of public keys of valid workers. No authentication is performed
         if file not given.
 
-    server_host_ip: str
+    server_host_ip: str (default None)
         The hostname or IP address the server will bind to.
         If not given, it will default to the machine IP.
+
+    server_port: int (default 8080)
+        The port at which the server should listen to.
 
     ssl_enabled: bool (default False)
         Enable SSL/TLS for server/workers communications.
@@ -55,7 +58,15 @@ class FedAvgServer(object):
         This is mandatory if ssl_enabled is True, ignored otherwise.
     """
 
-    def __init__(self, global_model_trainer, key_list_file, update_lim=10, server_host_ip=None, ssl_enabled=False, ssl_keyfile=None, ssl_certfile=None):
+    def __init__(self,
+                 global_model_trainer,
+                 key_list_file,
+                 update_lim=10,
+                 server_host_ip=None,
+                 server_port=8080,
+                 ssl_enabled=False,
+                 ssl_keyfile=None,
+                 ssl_certfile=None):
         logger.info(
             f"Initializing FedAvg server for model class {global_model_trainer.get_model().__class__.__name__}")
 
@@ -74,6 +85,7 @@ class FedAvgServer(object):
             load_last_session_workers=False,
             key_list_file=key_list_file,
             server_host_ip=server_host_ip,
+            server_port=server_port,
             ssl_enabled=ssl_enabled,
             ssl_keyfile=ssl_keyfile,
             ssl_certfile=ssl_certfile,

--- a/src/dc_federated/backend/dcf_server.py
+++ b/src/dc_federated/backend/dcf_server.py
@@ -52,7 +52,7 @@ class DCFServer(object):
     return_global_model_callback: () -> dict
         This function is expected to return a dictionary with the
         GLOBAL_MODEL: containing the serialization of the global model
-        GLOBAL_MODEL_VERSION: containing the global model itself.
+        GLOBAL_MODEL_VERSION: the global model version (algorithm specific).
 
     is_global_model_most_recent:  str -> bool
         Returns the True if the model version given in the string is the

--- a/src/dc_federated/examples/mnist/mnist_fed_avg_server.py
+++ b/src/dc_federated/examples/mnist/mnist_fed_avg_server.py
@@ -38,6 +38,11 @@ def get_args():
                    type=str,
                    required=False,
                    default=None)
+    p.add_argument("--server-port",
+                   help="The port at which the server listens.",
+                   type=int,
+                   required=False,
+                   default=8080)
 
     args, rest = p.parse_known_args()
 
@@ -66,6 +71,7 @@ def run():
                                   key_list_file=args.key_list_file,
                                   update_lim=3,
                                   server_host_ip=args.server_host_ip,
+                                  server_port=args.server_port,
                                   ssl_enabled=args.ssl_enabled,
                                   ssl_keyfile=args.ssl_keyfile,
                                   ssl_certfile=args.ssl_certfile)

--- a/src/dc_federated/examples/plantvillage/plant_fed_avg_server.py
+++ b/src/dc_federated/examples/plantvillage/plant_fed_avg_server.py
@@ -21,21 +21,29 @@ def get_args():
                    help="The path to the train data.",
                    type=str,
                    required=False)
-
     p.add_argument("--validation-data-path",
                    help="The path to the validation data.",
                    type=str,
                    required=False)
-
     p.add_argument("--checkpoint-path",
                    help="The path to save the global model checkpoint.",
                    type=str,
                    required=False)
-
     p.add_argument("--update-lim",
                    help="The number of desired workers updates ber iteration.",
                    type=str,
                    required=False)
+    p.add_argument("--server-host-ip",
+                   help="The hostname or ip address of the server.",
+                   type=str,
+                   required=False,
+                   default=None)
+    p.add_argument("--server-port",
+                   help="The port at which the server listens.",
+                   type=int,
+                   required=False,
+                   default=8080)
+
 
     return p.parse_args()
 
@@ -68,6 +76,8 @@ def run():
     )
 
     fed_avg_server = FedAvgServer(global_model_trainer=global_model_trainer,
+                                  server_host_ip=args.server_host_ip,
+                                  server_port=args.server_port,
                                   key_list_file=None,
                                   update_lim=args.update_lim)
     print("\n******** FEDERATED LEARNING EXPERIMENT ********")


### PR DESCRIPTION
---
name:  Add server-port option to FedAvgServer and the two example
about: 
---


## Summary

The current implementation of FedAvg does not allow the caller to specify the server port which seems like an unnecessary limitation.  This PR fixes that issue. This also requires updating the server script for the two examples MNIST and PlantVillage.

## Motivation

Improve usability of the FedAvg algorithm.

## Describe alternatives you've considered

Leaving it as it is, which is limiting.

## Additional context

N/A.