### PR TITLE
Fix Issue #7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ pyparsing==2.4.7
 pytest==6.0.1
 pytest-cov==2.10.1
 PyYAML==5.3.1
+pyzmq==22.3.0
 requests==2.22.0
 six==1.15.0
 tinydb==4.1.1
@@ -49,5 +50,6 @@ torch==1.4.0
 torchvision==0.5.0
 urllib3==1.25.10
 zipp==3.2.0
+zmq==0.0.0
 zope.event==4.5.0
 zope.interface==5.1.0

--- a/src/dc_federated/algorithms/fed_avg/fed_avg_server.py
+++ b/src/dc_federated/algorithms/fed_avg/fed_avg_server.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from collections import OrderedDict
 
 import torch
-from dc_federated.backend import DCFServer, \
+from dc_federated.backend import DCFServerHandler as DCFServer, \
     GLOBAL_MODEL_VERSION, GLOBAL_MODEL
 
 from dc_federated.backend._constants import *

--- a/src/dc_federated/backend/__init__.py
+++ b/src/dc_federated/backend/__init__.py
@@ -1,4 +1,4 @@
-from dc_federated.backend.dcf_server import DCFServer
+from dc_federated.backend.dcf_server import DCFServer, DCFServerHandler
 from dc_federated.backend.dcf_worker import DCFWorker
 from dc_federated.backend._constants import GLOBAL_MODEL, \
     GLOBAL_MODEL_VERSION, LAST_WORKER_MODEL_VERSION, WID_LEN

--- a/src/dc_federated/backend/subprocess_dcf_server.py
+++ b/src/dc_federated/backend/subprocess_dcf_server.py
@@ -18,7 +18,6 @@ logger.setLevel(level=logging.INFO)
 def run(port):
     logger.info("Starting server as a subprocess.")
 
-    print(ZMQInterfaceServer)
     zmqi = ZMQInterfaceServer(port)
     server_subprocess_args = zmqi.server_args_request_send()
 

--- a/src/dc_federated/backend/subprocess_dcf_server.py
+++ b/src/dc_federated/backend/subprocess_dcf_server.py
@@ -1,0 +1,37 @@
+"""
+A script for running the DCFServer without a federated learning algorithm.
+Instead the callbacks are implemented as ZeroMQ messages using the 
+ZMQ Interface defined in dc_federated.backend.zmq_interface. This script is
+intended to be run from the DCFServerHandler defined in dc_federated.backend.dcf_server.
+"""
+
+from dc_federated.backend.dcf_server import DCFServer
+from dc_federated.backend.zmq_interface import ZMQInterfaceServer
+
+import logging
+import sys
+
+logger = logging.getLogger(__name__)
+logger.setLevel(level=logging.INFO)
+
+
+def run(port):
+    logger.info("Starting server as a subprocess.")
+
+    print(ZMQInterfaceServer)
+    zmqi = ZMQInterfaceServer(port)
+    server_subprocess_args = zmqi.server_args_request_send()
+
+    server = DCFServer(
+        register_worker_callback=zmqi.register_worker_send,
+        unregister_worker_callback=zmqi.unregister_worker_send,
+        return_global_model_callback=zmqi.return_global_model_send,
+        is_global_model_most_recent=zmqi.is_global_model_most_recent_send,
+        receive_worker_update_callback=zmqi.receive_worker_update_send,
+        **server_subprocess_args,
+    )
+    server.start_server()
+
+
+if __name__ == "__main__":
+    run(port=sys.argv[1])

--- a/src/dc_federated/backend/zmq_interface.py
+++ b/src/dc_federated/backend/zmq_interface.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(level=logging.INFO)
 
 
-class ZMQInterfaceModel:
+class ZMQInterfaceModel(object):
     def __init__(
         self,
         socket,
@@ -61,37 +61,49 @@ class ZMQInterfaceModel:
             )
 
 
-class ZMQInterfaceServer:
+class ZMQInterfaceServer(object):
     def __init__(self, port) -> None:
         self.port = port
 
     def server_args_request_send(self):
         socket = self._send([b"server_args_request"])
-        return socket.recv_pyobj()
+        output = socket.recv_pyobj()
+        socket.close()
+        return output
 
     def register_worker_send(self, worker_id):
         socket = self._send([b"register_worker", worker_id.encode("utf-8")])
-        return socket.recv()
+        output = socket.recv()
+        socket.close()
+        return output
 
     def unregister_worker_send(self, worker_id):
         socket = self._send([b"unregister_worker", worker_id.encode("utf-8")])
-        return socket.recv()
+        output = socket.recv()
+        socket.close()
+        return output
 
     def return_global_model_send(self):
         socket = self._send([b"return_global_model"])
-        return socket.recv_pyobj()
+        output = socket.recv_pyobj()
+        socket.close()
+        return output
 
     def is_global_model_most_recent_send(self, model_version):
         socket = self._send(
             [b"is_global_model_most_recent", str(model_version).encode("utf-8")]
         )
-        return socket.recv_pyobj()
+        output = socket.recv_pyobj()
+        socket.close()
+        return output
 
     def receive_worker_update_send(self, worker_id, model_update):
         socket = self._send(
             [b"receive_worker_update", worker_id.encode("utf-8"), model_update]
         )
-        return socket.recv_string()
+        output = socket.recv_string()
+        socket.close()
+        return output
 
     def _new_socket(self):
         context = zmq.Context()

--- a/src/dc_federated/backend/zmq_interface.py
+++ b/src/dc_federated/backend/zmq_interface.py
@@ -10,6 +10,13 @@ logger.setLevel(level=logging.INFO)
 
 
 class ZMQInterfaceModel(object):
+    """
+    The model-side ZMQ interface definition for communicating with the web
+    server process. It handles ZMQ and the serialisation and exposes the same
+    API that federated algorithm expects for communicating with the DCFServer.
+    The API is split into the callback functions defined in DCFServer plus the
+    non-functional remaining server_subprocess_args.
+    """
     def __init__(
         self,
         socket,
@@ -29,6 +36,12 @@ class ZMQInterfaceModel(object):
         self.server_subprocess_args = server_subprocess_args
 
     def receive(self):
+        """
+        Wait for a multipart message on the socket. Based on the first 'part'
+        (a string key) which specifies the function the arguments are sent to
+        one of the callbacks and returns sent back. The exception is 
+        "server_args_request" where server_subprocess_args is returned.
+        """
         message = self.socket.recv_multipart()
         logger.debug(f"Zmq message received: {message[0]}")
 
@@ -62,34 +75,96 @@ class ZMQInterfaceModel(object):
 
 
 class ZMQInterfaceServer(object):
+    """
+    The server-side ZMQ interface definition for communicating with the model
+    aggregation process. It handles ZMQ and the serialisation and exposes the same
+    API that DCFServer expects for communicating with the federated algorithm.
+    The API is a list of callbacks, the same as in DCFServer, with an additional
+    callback for getting the non-functional arguments for running the server.
+    """
     def __init__(self, port) -> None:
         self.port = port
 
     def server_args_request_send(self):
+        """
+        Send request for non-functional server args supplied to
+        ZMQInterfaceModel.
+
+        Returns
+        -------
+
+        dict:
+            dict of non-functional args to be passed to DCFServer. keys:
+            server_mode_safe, key_list_file, load_last_session_workers,
+            path_to_keys_db, server_host_ip, server_port, ssl_enabled,
+            ssl_keyfile, ssl_certfile, model_check_interval, debug
+        """
         socket = self._send([b"server_args_request"])
         output = socket.recv_pyobj()
         socket.close()
         return output
 
     def register_worker_send(self, worker_id):
+        """
+        Send request to register_worker_callback from ZMQInterfaceModel.
+
+        Parameters
+        ----------
+        worker_id: str
+            The id of the worker to be handled by the function.
+
+        Returns
+        -------
+
+        str:
+            '1' to confirm receipt.
+        """
         socket = self._send([b"register_worker", worker_id.encode("utf-8")])
         output = socket.recv()
         socket.close()
         return output
 
     def unregister_worker_send(self, worker_id):
+        """
+        Send request to unregister_worker_callback from ZMQInterfaceModel.
+
+        Parameters
+        ----------
+        worker_id: str
+            The id of the worker to be handled by the function.
+
+        Returns
+        -------
+
+        str:
+            '1' to confirm receipt.
+        """
         socket = self._send([b"unregister_worker", worker_id.encode("utf-8")])
         output = socket.recv()
         socket.close()
         return output
 
     def return_global_model_send(self):
+        """
+        Send request to return_global_model_callback from ZMQInterfaceModel.
+        Returns what that function returns.
+        """
         socket = self._send([b"return_global_model"])
         output = socket.recv_pyobj()
         socket.close()
         return output
 
     def is_global_model_most_recent_send(self, model_version):
+        """
+        Send request to is_global_model_most_recent from ZMQInterfaceModel.
+        Returns what that function returns. Which, in the case of FedAvgServer
+        is a bool.
+
+        Parameters
+        ----------
+        model_version: int
+            The version of the model version to check.
+        """
         socket = self._send(
             [b"is_global_model_most_recent", str(model_version).encode("utf-8")]
         )
@@ -98,6 +173,18 @@ class ZMQInterfaceServer(object):
         return output
 
     def receive_worker_update_send(self, worker_id, model_update):
+        """
+        Send request to return_global_model_callback from ZMQInterfaceModel.
+        Returns the string that function returns.
+
+        Parameters
+        ----------
+        worker_id: str
+            the worker id submitting the update.
+
+        model_update: 
+            serialised model.
+        """
         socket = self._send(
             [b"receive_worker_update", worker_id.encode("utf-8"), model_update]
         )
@@ -106,12 +193,28 @@ class ZMQInterfaceServer(object):
         return output
 
     def _new_socket(self):
+        """
+        Internal function for creating a new ZMQ socket.
+
+        Returns
+        ----------
+        ZMQ Socket: 
+            The created socket
+        """
         context = zmq.Context()
         socket = context.socket(zmq.REQ)
         socket.connect(f"tcp://localhost:{self.port}")
         return socket
 
     def _send(self, args):
+        """
+        Internal function for sending a multipart message on the zmq socket.
+
+        Returns
+        ----------
+        ZMQ Socket: 
+            The created socket
+        """
         socket = self._new_socket()
         logger.debug(f"Sending zmq message: {args}")
         socket.send_multipart(args)

--- a/src/dc_federated/backend/zmq_interface.py
+++ b/src/dc_federated/backend/zmq_interface.py
@@ -1,0 +1,107 @@
+"""
+Two classes for defining the ZeroMQ interface between the server and the model.
+"""
+
+import zmq
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(level=logging.INFO)
+
+
+class ZMQInterfaceModel:
+    def __init__(
+        self,
+        socket,
+        register_worker_callback,
+        unregister_worker_callback,
+        return_global_model_callback,
+        is_global_model_most_recent,
+        receive_worker_update_callback,
+        server_subprocess_args,
+    ) -> None:
+        self.socket = socket
+        self.register_worker_callback = register_worker_callback
+        self.unregister_worker_callback = unregister_worker_callback
+        self.return_global_model_callback = return_global_model_callback
+        self.is_global_model_most_recent = is_global_model_most_recent
+        self.receive_worker_update_callback = receive_worker_update_callback
+        self.server_subprocess_args = server_subprocess_args
+
+    def receive(self):
+        message = self.socket.recv_multipart()
+        logger.debug(f"Zmq message received: {message[0]}")
+
+        # Server initialisation data request
+        if message[0] == b"server_args_request":
+            self.socket.send_pyobj(self.server_subprocess_args)
+        # Federated Learning API
+        elif message[0] == b"register_worker":
+            self.register_worker_callback(message[1].decode("utf-8"))
+            self.socket.send(b"1")
+        elif message[0] == b"unregister_worker":
+            self.unregister_worker_callback(message[1].decode("utf-8"))
+            self.socket.send(b"1")
+        elif message[0] == b"return_global_model":
+            global_model = self.return_global_model_callback()
+            self.socket.send_pyobj(global_model)
+        elif message[0] == b"is_global_model_most_recent":
+            most_recent = self.is_global_model_most_recent(
+                int(message[1].decode("utf-8"))
+            )
+            self.socket.send_pyobj(most_recent)
+        elif message[0] == b"receive_worker_update":
+            status = self.receive_worker_update_callback(
+                message[1].decode("utf-8"), message[2]
+            )
+            self.socket.send_string(status)
+        else:
+            logger.error(
+                f'ZQM messaging interface received unrecognised message type: "{message[0]}"'
+            )
+
+
+class ZMQInterfaceServer:
+    def __init__(self, port) -> None:
+        self.port = port
+
+    def server_args_request_send(self):
+        socket = self._send([b"server_args_request"])
+        return socket.recv_pyobj()
+
+    def register_worker_send(self, worker_id):
+        socket = self._send([b"register_worker", worker_id.encode("utf-8")])
+        return socket.recv()
+
+    def unregister_worker_send(self, worker_id):
+        socket = self._send([b"unregister_worker", worker_id.encode("utf-8")])
+        return socket.recv()
+
+    def return_global_model_send(self):
+        socket = self._send([b"return_global_model"])
+        return socket.recv_pyobj()
+
+    def is_global_model_most_recent_send(self, model_version):
+        socket = self._send(
+            [b"is_global_model_most_recent", str(model_version).encode("utf-8")]
+        )
+        return socket.recv_pyobj()
+
+    def receive_worker_update_send(self, worker_id, model_update):
+        socket = self._send(
+            [b"receive_worker_update", worker_id.encode("utf-8"), model_update]
+        )
+        return socket.recv_string()
+
+    def _new_socket(self):
+        context = zmq.Context()
+        socket = context.socket(zmq.REQ)
+        socket.connect(f"tcp://localhost:{self.port}")
+        return socket
+
+    def _send(self, args):
+        socket = self._new_socket()
+        logger.debug(f"Sending zmq message: {args}")
+        socket.send_multipart(args)
+        logger.debug(f"Message sent.")
+        return socket

--- a/tests/test_DCFServerHandler.py
+++ b/tests/test_DCFServerHandler.py
@@ -1,0 +1,39 @@
+import os
+import subprocess
+from inspect import signature
+from unittest.mock import patch, Mock
+
+from dc_federated import backend
+from dc_federated.backend import DCFServer, DCFServerHandler
+
+
+def test_dcfServerHandler_interface():
+    """
+    Tests the signature/args for the DCFServerHandler class matches that of
+    the DCFServer class so that it can be used as a drop-in replacement.
+    """
+    handler_params = list(signature(DCFServerHandler).parameters.values())
+    for i, param in enumerate(signature(DCFServer).parameters.values()):
+        assert param == handler_params[i]
+
+
+@patch.object(subprocess, "Popen")
+def test_opens_subprocess(Popen_mock):
+    """
+    Tests that the DCFServerHandler object starts the subprocesses script and
+    with the port as an arg. The mocking at the start it to stop it from
+    initialising sockets that are not part of this test.
+    """
+    server = DCFServerHandler(
+        Mock(), Mock(), Mock(), Mock(), Mock(), False, None, socket_port="test_port"
+    )
+    server.initialise_zmq = Mock()
+    server.__del__ = Mock()
+    server.wait_for_messages = Mock()
+    server.start_server()
+
+    backend_root = os.path.dirname(backend.__file__)
+    assert (
+        Popen_mock.call_args[0][0]
+        == f"python {backend_root}/subprocess_dcf_server.py test_port"
+    )

--- a/tests/test_DCFServerHandler.py
+++ b/tests/test_DCFServerHandler.py
@@ -25,7 +25,14 @@ def test_opens_subprocess(Popen_mock):
     initialising sockets that are not part of this test.
     """
     server = DCFServerHandler(
-        Mock(), Mock(), Mock(), Mock(), Mock(), False, None, socket_port="test_port"
+        register_worker_callback=Mock(),
+        unregister_worker_callback=Mock(),
+        return_global_model_callback=Mock(),
+        is_global_model_most_recent=Mock(),
+        receive_worker_update_callback=Mock(),
+        server_mode_safe=False,
+        key_list_file=None,
+        socket_port="test_port"
     )
     server.initialise_zmq = Mock()
     server.__del__ = Mock()

--- a/tests/test_subprocess_dcf_server.py
+++ b/tests/test_subprocess_dcf_server.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch, ANY
+from dc_federated.backend.zmq_interface import ZMQInterfaceServer
+from dc_federated.backend.dcf_server import DCFServer
+from dc_federated.backend.subprocess_dcf_server import run as run_subprocess
+
+server_subprocess_args = {"arg1": "test1", "arg2": "test2"}
+
+
+@patch.object(
+    ZMQInterfaceServer, "server_args_request_send", return_value=server_subprocess_args
+)
+@patch.object(ZMQInterfaceServer, "__init__", return_value=None)
+@patch.object(DCFServer, "start_server")
+@patch.object(DCFServer, "__init__", return_value=None)
+def test_requests_args(
+    DCFServer_init_mock, DCFServer_start_mock, ZQMIS_init_mock, server_args_request_mock
+):
+    """
+    Tests that the script initialises the ZMQ interface correctly and starts
+    the server with the correct args.
+    """
+    run_subprocess("test_port")
+    ZQMIS_init_mock.assert_called_once_with("test_port")
+    server_args_request_mock.assert_called_once_with()
+    DCFServer_init_mock.assert_called_once_with(
+        register_worker_callback=ANY,
+        unregister_worker_callback=ANY,
+        return_global_model_callback=ANY,
+        is_global_model_most_recent=ANY,
+        receive_worker_update_callback=ANY,
+        **server_subprocess_args,
+    )
+    DCFServer_start_mock.assert_called_once_with()

--- a/tests/test_zmq_interface.py
+++ b/tests/test_zmq_interface.py
@@ -8,14 +8,14 @@ import pytest
 # Initalise some mocks that can be used in place of the callbacks to check that
 # they are called. Along with some other constants that are used to check for
 # equality in the tests.
-register_worker_callback = Mock()
-unregister_worker_callback = Mock()
+mock_register_worker_callback = Mock()
+mock_unregister_worker_callback = Mock()
 GLOBAL_MODEL = {"test": "test_val"}
-return_global_model_callback = Mock(return_value=GLOBAL_MODEL)
+mock_return_global_model_callback = Mock(return_value=GLOBAL_MODEL)
 IS_MOST_RECENT = True
-is_global_model_most_recent = Mock(return_value=IS_MOST_RECENT)
+mock_is_global_model_most_recent = Mock(return_value=IS_MOST_RECENT)
 WORKER_UPDATE = "test_string"
-receive_worker_update_callback = Mock(return_value=WORKER_UPDATE)
+mock_receive_worker_update_callback = Mock(return_value=WORKER_UPDATE)
 server_subprocess_args = ["test", "subprocess", "args", 1, True, None]
 port = 5556
 
@@ -77,11 +77,11 @@ def run_model_interface():
 
     zmqM = ZMQInterfaceModel(
         socket=socket,
-        register_worker_callback=register_worker_callback,
-        unregister_worker_callback=unregister_worker_callback,
-        return_global_model_callback=return_global_model_callback,
-        is_global_model_most_recent=is_global_model_most_recent,
-        receive_worker_update_callback=receive_worker_update_callback,
+        register_worker_callback=mock_register_worker_callback,
+        unregister_worker_callback=mock_unregister_worker_callback,
+        return_global_model_callback=mock_return_global_model_callback,
+        is_global_model_most_recent=mock_is_global_model_most_recent,
+        receive_worker_update_callback=mock_receive_worker_update_callback,
         server_subprocess_args=server_subprocess_args,
     )
     thread = threading.Thread(target=zmqM.receive, daemon=True)
@@ -104,32 +104,32 @@ def test_server_args_request():
 def test_register_worker():
     result = zmqS.register_worker_send("test123")
     assert result == b"1"
-    register_worker_callback.assert_called_once_with("test123")
+    mock_register_worker_callback.assert_called_once_with("test123")
 
 
 @patch.object(zmqS, "_new_socket", mock_new_socket)
 def test_unregister_worker():
     result = zmqS.unregister_worker_send("test123")
     assert result == b"1"
-    unregister_worker_callback.assert_called_once_with("test123")
+    mock_unregister_worker_callback.assert_called_once_with("test123")
 
 
 @patch.object(zmqS, "_new_socket", mock_new_socket)
 def test_return_global_model():
     result = zmqS.return_global_model_send()
     assert result == GLOBAL_MODEL
-    return_global_model_callback.assert_called_once_with()
+    mock_return_global_model_callback.assert_called_once_with()
 
 
 @patch.object(zmqS, "_new_socket", mock_new_socket)
 def test_is_global_model_most_recent():
     result = zmqS.is_global_model_most_recent_send(123)
     assert result == IS_MOST_RECENT
-    is_global_model_most_recent.assert_called_once_with(123)
+    mock_is_global_model_most_recent.assert_called_once_with(123)
 
 
 @patch.object(zmqS, "_new_socket", mock_new_socket)
 def test_receive_worker_update():
     result = zmqS.receive_worker_update_send("test123", b"model_update")
     assert result == WORKER_UPDATE
-    receive_worker_update_callback.assert_called_once_with("test123", b"model_update")
+    mock_receive_worker_update_callback.assert_called_once_with("test123", b"model_update")

--- a/tests/test_zmq_interface.py
+++ b/tests/test_zmq_interface.py
@@ -1,0 +1,135 @@
+from dc_federated.backend.zmq_interface import ZMQInterfaceModel, ZMQInterfaceServer
+import zmq
+from unittest.mock import Mock, patch
+import threading
+import time
+import pytest
+
+# Initalise some mocks that can be used in place of the callbacks to check that
+# they are called. Along with some other constants that are used to check for
+# equality in the tests.
+register_worker_callback = Mock()
+unregister_worker_callback = Mock()
+GLOBAL_MODEL = {"test": "test_val"}
+return_global_model_callback = Mock(return_value=GLOBAL_MODEL)
+IS_MOST_RECENT = True
+is_global_model_most_recent = Mock(return_value=IS_MOST_RECENT)
+WORKER_UPDATE = "test_string"
+receive_worker_update_callback = Mock(return_value=WORKER_UPDATE)
+server_subprocess_args = ["test", "subprocess", "args", 1, True, None]
+port = 5556
+
+
+def mock_recv(context, socket, fn_name, close=True):
+    """
+    A function that takes a zmq recv function and mocks it from being a
+    blocking call to a polled call. This means that it can be threaded using
+    the same interpreter without preventing the test from continuing/finishing.
+    """
+
+    original_recv = getattr(socket, fn_name)  # Hold original recv function
+
+    def recv_py(flags=0):
+        poller = zmq.Poller()
+        poller.register(socket, zmq.POLLIN)
+        while True:
+            evts = poller.poll(500)
+            if len(evts) > 0:
+                # If we get a message call the original blocking recv
+                result = original_recv(flags=flags)
+                if close:
+                    socket.close()
+                    context.term()
+                return result
+            # Release the GIL to send/receive messages on the other socket.
+            time.sleep(0.5)
+
+    setattr(socket, fn_name, Mock(side_effect=recv_py))
+
+
+def mock_new_socket():
+    """
+    A function for mocking the ZMQInterfaceServer `_new_socket` function that
+    converts the relevant "recv" functions from blocking to non-blocking.
+    """
+    context = zmq.Context()
+    socket = context.socket(zmq.REQ)
+    socket.connect(f"tcp://localhost:{port}")
+
+    mock_recv(context, socket, "recv_pyobj")
+    mock_recv(context, socket, "recv")
+    mock_recv(context, socket, "recv_string")
+    return socket
+
+
+@pytest.fixture(autouse=True)
+def run_model_interface():
+    """
+    A function for initialising the REP socket that is initialised by the
+    model-process. This is done in its own thread with a non-blocking
+    `recv_multipart` so that the server-process can send/receive messages too.
+    """
+    context = zmq.Context()
+    socket = context.socket(zmq.REP)
+    socket.bind(f"tcp://*:{port}")
+
+    mock_recv(context, socket, "recv_multipart", close=False)
+
+    zmqM = ZMQInterfaceModel(
+        socket=socket,
+        register_worker_callback=register_worker_callback,
+        unregister_worker_callback=unregister_worker_callback,
+        return_global_model_callback=return_global_model_callback,
+        is_global_model_most_recent=is_global_model_most_recent,
+        receive_worker_update_callback=receive_worker_update_callback,
+        server_subprocess_args=server_subprocess_args,
+    )
+    thread = threading.Thread(target=zmqM.receive, daemon=True)
+    thread.start()
+    yield thread
+    socket.close()
+    context.term()
+
+
+zmqS = ZMQInterfaceServer(port=port)
+
+# Test each of the interface's functions
+@patch.object(zmqS, "_new_socket", mock_new_socket)
+def test_server_args_request():
+    result = zmqS.server_args_request_send()
+    assert result == server_subprocess_args
+
+
+@patch.object(zmqS, "_new_socket", mock_new_socket)
+def test_register_worker():
+    result = zmqS.register_worker_send("test123")
+    assert result == b"1"
+    register_worker_callback.assert_called_once_with("test123")
+
+
+@patch.object(zmqS, "_new_socket", mock_new_socket)
+def test_unregister_worker():
+    result = zmqS.unregister_worker_send("test123")
+    assert result == b"1"
+    unregister_worker_callback.assert_called_once_with("test123")
+
+
+@patch.object(zmqS, "_new_socket", mock_new_socket)
+def test_return_global_model():
+    result = zmqS.return_global_model_send()
+    assert result == GLOBAL_MODEL
+    return_global_model_callback.assert_called_once_with()
+
+
+@patch.object(zmqS, "_new_socket", mock_new_socket)
+def test_is_global_model_most_recent():
+    result = zmqS.is_global_model_most_recent_send(123)
+    assert result == IS_MOST_RECENT
+    is_global_model_most_recent.assert_called_once_with(123)
+
+
+@patch.object(zmqS, "_new_socket", mock_new_socket)
+def test_receive_worker_update():
+    result = zmqS.receive_worker_update_send("test123", b"model_update")
+    assert result == WORKER_UPDATE
+    receive_worker_update_callback.assert_called_once_with("test123", b"model_update")


### PR DESCRIPTION
---
name: Fix [issue 7](https://github.com/digicatapult/dc-federated/issues/7)
about: Federated learning blocks on Linux machines.
---

## Summary

Allows for the running of the web server and model aggregation in separate processes so as not to have conflicts between pytorch and gevent causing blocking.

## Motivation

This means that the library works on Linux machines without the use of [workarounds](https://github.com/digicatapult/dc-federated/tree/feature/fix-gevent-pytorch).

## Describe alternatives you've considered

1. This [workaround](https://github.com/digicatapult/dc-federated/tree/feature/fix-gevent-pytorch) to convert to numpy arrays and back is a simpler solution but less efficient.
2. Using [base linux sockets](https://docs.python.org/3/library/socket.html) rather than ZMQ would reduce dependencies but would make for a more complex codebase potentially increasing mistakes.
3. Not separating into multiple process but instead relying on threading or multiprocessing does not solve the problem due to gevent modifying global dependencies.

## Additional context

- This fix has been designed to not be a breaking change.
- This update will not automatically fix this problem on Linux machines not using the included "federated average" algorithm. Custom algorithms would have to make the same change made to `fed_avg_server.py` as in this PR, shown [here](https://github.com/digicatapult/dc-federated/compare/fix_issue_7_blocking_on_linux?expand=1#diff-57d1c95cc03d1b8c6135be7f4942fa61f613782155dc04d79e4f025c078af04bL11). We may want to consider obfuscating this functionality further by replacing `DCFServer` altogether with `DCFServerHandler`. This would upgrade users custom algorithms automatically.